### PR TITLE
Map: remove empty maps from results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.5+1] - 1st of September 2020
+
+- Map: remove empty maps from results in `deepSearchByKey` and `deepSearchByValue`
+
 ## [0.1.5] - 1st of September 2020
 
 - Map: add `deepSearchByKey`

--- a/lib/src/map.dart
+++ b/lib/src/map.dart
@@ -17,7 +17,8 @@ extension DeepMap<K, V> on Map<K, V> {
               return this[k];
             }
           })
-        ..removeWhere((key, value) => key == null || value == null);
+        ..removeWhere(
+            (key, value) => value == null || (value is Map && value.isEmpty));
 
   /// Returns new instance of recursively filtered (by value) [Map].
   /// Does not work with nested [List] and [Set] yet.
@@ -31,7 +32,8 @@ extension DeepMap<K, V> on Map<K, V> {
               return this[k];
             }
           })
-        ..removeWhere((key, value) => value == null);
+        ..removeWhere(
+            (key, value) => value == null || (value is Map && value.isEmpty));
 
   /// Returns new instance of recursively reversed [Map].
   /// It reverses nested [List], [Set] or [Map] (primitive collections),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deep_collection
 description: Extends [List], [Set] and [Map] in order to add commonly used recursive methods such as sorting, reversing, finding intersections or differences.
-version: 0.1.5
+version: 0.1.5+1
 homepage: https://github.com/owczaro/deep_collection
 
 environment:

--- a/test/src/map_test.dart
+++ b/test/src/map_test.dart
@@ -82,6 +82,17 @@ void main() {
       expect((filteredMap['a'] as Map).keys, orderedEquals(['q']));
     });
 
+    test('Nested map - no match', () {
+      final map = {
+        'c': 'c',
+        'a': {'x': 'c', 'z': 'b', 'q': 'a'},
+        'b': 'b'
+      };
+      final filteredMap = map.deepSearchByKey((key) => key == 'q-no-ma');
+
+      expect(filteredMap, isEmpty);
+    });
+
     test('Nested map - match in main list and sublist', () {
       final map = {
         'c': 'c',
@@ -164,6 +175,17 @@ void main() {
       expect(
           filteredMap.values, unorderedEquals([1.3, 2, 1, 'a', 'c', 3, 2.1]));
       expect(filteredMap.keys, unorderedEquals([1.3, 2, 1, 'a', 'c', 3, 2.1]));
+    });
+
+    test('Nested map - no match', () {
+      final map = {
+        'c': 'c',
+        'a': {'x': 'c', 'z': 'b', 'q': 'a'},
+        'b': 'b'
+      };
+      final filteredMap = map.deepSearchByValue((value) => value == 'a-no-ma');
+
+      expect(filteredMap.keys, isEmpty);
     });
 
     test('Nested map - match in sublist', () {


### PR DESCRIPTION
- Map: remove empty maps from results in `deepSearchByKey` and `deepSearchByValue`